### PR TITLE
Removing UIKit to prepare the way to support OS X with this library

### DIFF
--- a/DeskAPIClient/DeskAPIClient/DSAPINetworkIndicatorController.h
+++ b/DeskAPIClient/DeskAPIClient/DSAPINetworkIndicatorController.h
@@ -28,7 +28,10 @@
 //  POSSIBILITY OF SUCH DAMAGE.
 //
 
+#import <Foundation/Foundation.h>
+#if TARGET_OS_IPHONE
 #import <UIKit/UIKit.h>
+#endif
 
 @interface DSAPINetworkIndicatorController : NSObject
 

--- a/DeskAPIClient/DeskAPIClient/DSAPINetworkIndicatorController.m
+++ b/DeskAPIClient/DeskAPIClient/DSAPINetworkIndicatorController.m
@@ -64,24 +64,28 @@
 
 - (void)networkActivityDidStart
 {
+#if TARGET_OS_IPHONE
     NSAssert([NSThread isMainThread], @"Altering network activity indicator state can only be done on the main thread.");
     self.activityCount++;
     [self updateIndicatorVisibility];
+#endif
 }
 
 - (void)networkActivityDidEnd
 {
+#if TARGET_OS_IPHONE
     NSAssert([NSThread isMainThread], @"Altering network activity indicator state can only be done on the main thread.");
     NSAssert(self.activityCount > 0, @"networkActivityDidEnd before matching networkActivityDidStart");
     self.activityCount--;
     [self updateIndicatorVisibility];
-    
+ #endif
 }
 
 #pragma mark - Private
 
 - (void)updateIndicatorVisibility
 {
+#if TARGET_OS_IPHONE
     if (self.activityCount > 0) {
         [self showIndicator];
     } else {
@@ -92,31 +96,40 @@
          */
         [self createTimerToHideIndicator];
     }
+#endif
 }
 
 - (void)createTimerToHideIndicator
 {
+#if TARGET_OS_IPHONE
     self.timer = [NSTimer scheduledTimerWithTimeInterval:0.75 target:self selector:@selector(timerFireMethod:) userInfo:nil repeats:NO];
     self.timer.tolerance = 0.5;
+#endif
 }
 
 - (void)timerFireMethod:(NSTimer *)timer
 {
+#if TARGET_OS_IPHONE
     [self hideIndicator];
+#endif
 }
 
 - (void)showIndicator
 {
+#if TARGET_OS_IPHONE
     [self.timer invalidate];
     self.timer = nil;
     [UIApplication sharedApplication].networkActivityIndicatorVisible = YES;
+#endif
 }
 
 - (void)hideIndicator
 {
+#if TARGET_OS_IPHONE
     [self.timer invalidate];
     self.timer = nil;
     [UIApplication sharedApplication].networkActivityIndicatorVisible = NO;
+#endif
 }
 
 

--- a/DeskAPIClient/DeskAPIClientTests/DSAPIBrandTests.m
+++ b/DeskAPIClient/DeskAPIClientTests/DSAPIBrandTests.m
@@ -28,7 +28,7 @@
 //  POSSIBILITY OF SUCH DAMAGE.
 //
 
-#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
 #import "DSAPITestCase.h"
 
 @interface DSAPIBrandTests : DSAPITestCase

--- a/DeskAPIClient/DeskAPIClientTests/DSAPIListProviderTests.m
+++ b/DeskAPIClient/DeskAPIClientTests/DSAPIListProviderTests.m
@@ -28,7 +28,7 @@
 //  POSSIBILITY OF SUCH DAMAGE.
 //
 
-#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
 #import <XCTest/XCTest.h>
 #import "DSAPIResource+Testing.h"
 #import "DSAPIListProvider.h"

--- a/DeskAPIClient/DeskAPIClientTests/DSAPIPermissionTests.m
+++ b/DeskAPIClient/DeskAPIClientTests/DSAPIPermissionTests.m
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 Desk.com. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
 #import "DSAPITestCase.h"
 #import "DSAPIETagCache.h"
 

--- a/DeskAPIClient/DeskAPIClientTests/DSAPISiteTests.m
+++ b/DeskAPIClient/DeskAPIClientTests/DSAPISiteTests.m
@@ -28,7 +28,7 @@
 //  POSSIBILITY OF SUCH DAMAGE.
 //
 
-#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
 #import "DSAPITestCase.h"
 
 @interface DSAPISiteTests : DSAPITestCase

--- a/DeskAPIClient/DeskAPIClientTests/DeskAPIClientTests-Prefix.pch
+++ b/DeskAPIClient/DeskAPIClientTests/DeskAPIClientTests-Prefix.pch
@@ -5,7 +5,6 @@
 //
 
 #ifdef __OBJC__
-    #import <UIKit/UIKit.h>
     #import <Foundation/Foundation.h>
     #define EXP_SHORTHAND YES
     #import "Expecta.h"


### PR DESCRIPTION
This is for issue #35.

It is the first step to making project compatible with OSx. It removes UIKit from where it is not needed.

The class `DSAPINetworkIndicatorController` is left as is for iOS but the methods are essentially stubs for OSx. There are a few ways to handle this but I took the path of least amount of change before a new target is created.

This PR does not include a new OSx target as I wanted to keep the changes very focused on just removing UIKit wherever possible.

